### PR TITLE
Using our own CredentialProvider

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -479,7 +479,6 @@ module Fluent::Plugin
         options[:access_key_id] = @aws_key_id
         options[:secret_access_key] = @aws_sec_key
       when @assume_role_credentials
-        log.info "Trying to assume the role #{:role_arn}"
         c = @assume_role_credentials
         credentials_options[:role_arn] = c.role_arn
         credentials_options[:role_session_name] = c.role_session_name
@@ -489,8 +488,7 @@ module Fluent::Plugin
         if @s3_region
           credentials_options[:client] = Aws::STS::Client.new(region: @s3_region)
         end
-        options[:credentials] = Aws::AssumeRoleCredentials.new(credentials_options)
-        log.info "Successfully assumed the role #{:role_arn}"
+        options[:credentials] = EtleapAssumeRole.new(credentials_options)
       when @web_identity_credentials
         c = @web_identity_credentials
         credentials_options[:role_arn] = c.role_arn
@@ -628,6 +626,63 @@ module Fluent::Plugin
 
     def self.register_compressor(name, compressor)
       COMPRESSOR_REGISTRY.register(name, compressor)
+    end
+  end
+
+  ## The following class is an adaptation of: https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
+  class EtleapAssumeRole
+    include Aws::CredentialProvider
+    include Aws::RefreshingCredentials
+
+    # @option options [required, String] :role_arn
+    # @option options [required, String] :role_session_name
+    # @option options [String] :policy
+    # @option options [Integer] :duration_seconds
+    # @option options [String] :external_id
+    # @option options [STS::Client] :client
+    def initialize(options = {})
+      client_opts = {}
+      @assume_role_params = {}
+      options.each_pair do |key, value|
+        if self.class.assume_role_options.include?(key)
+          @assume_role_params[key] = value
+        else
+          client_opts[key] = value
+        end
+      end
+      @client = client_opts[:client] || Aws::STS::Client.new(client_opts)
+      super
+    end
+
+    # @return [STS::Client]
+    attr_reader :client
+
+    private
+
+    def refresh
+      c = @client.assume_role(@assume_role_params).credentials
+      @credentials = Aws::Credentials.new(
+        c.access_key_id,
+        c.secret_access_key,
+        c.session_token
+      )
+      @expiration = c.expiration
+    rescue Aws::STS::Errors::AccessDenied => e
+      # We need to set some credentials, to prevent an NPE further up the call stack.
+      @credentials = Aws::Credentials.new("invalid", "invalid", "invalid")
+      @expiration = 0
+    end
+
+    class << self
+
+      # @api private
+      def assume_role_options
+        @aro ||= begin
+          input = Aws::STS::Client.api.operation(:assume_role).input
+          Set.new(input.shape.member_names)
+        end
+      end
+
     end
   end
 end

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -488,7 +488,7 @@ module Fluent::Plugin
         if @s3_region
           credentials_options[:client] = Aws::STS::Client.new(region: @s3_region)
         end
-        options[:credentials] = EtleapAssumeRole.new(credentials_options)
+        options[:credentials] = EtleapAssumeRoleCredentials.new(credentials_options)
       when @web_identity_credentials
         c = @web_identity_credentials
         credentials_options[:role_arn] = c.role_arn
@@ -630,7 +630,7 @@ module Fluent::Plugin
   end
 
   ## The following class is an adaptation of: https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
-  class EtleapAssumeRole
+  class EtleapAssumeRoleCredentials
     include Aws::CredentialProvider
     include Aws::RefreshingCredentials
 

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -524,9 +524,7 @@ EOC
 
   def test_assume_role_credentials
     expected_credentials = Aws::Credentials.new("test_key", "test_secret")
-    mock(Aws::AssumeRoleCredentials).new(role_arn: "test_arn",
-                                         role_session_name: "test_session",
-                                         client: anything){
+    mock(Fluent::Plugin::EtleapAssumeRole).new(role_arn: "test_arn", role_session_name: "test_session", client: anything){
       expected_credentials
     }
     config = CONFIG_TIME_SLICE.split("\n").reject{|x| x =~ /.+aws_.+/}.join("\n")
@@ -547,9 +545,9 @@ EOC
     expected_credentials = Aws::Credentials.new("test_key", "test_secret")
     sts_client = Aws::STS::Client.new(region: 'ap-northeast-1')
     mock(Aws::STS::Client).new(region: 'ap-northeast-1'){ sts_client }
-    mock(Aws::AssumeRoleCredentials).new(role_arn: "test_arn",
-                                         role_session_name: "test_session",
-                                         client: sts_client){
+    mock(Fluent::Plugin::EtleapAssumeRole).new(role_arn: "test_arn",
+                                        role_session_name: "test_session",
+                                        client: anything){
       expected_credentials
     }
     config = CONFIG_TIME_SLICE.split("\n").reject{|x| x =~ /.+aws_.+/}.join("\n")
@@ -689,12 +687,12 @@ EOC
   end
 
   def test_assume_role_credentials_fail
-    setup_mocks
-    mock(Aws::AssumeRoleCredentials).new(
-      role_arn: "test_arn",
-      role_session_name: "test_session",
-      client: anything
-    ) { raise Aws::STS::Errors::AccessDenied.new("a", "b") }
+    expected_credentials = Aws::Credentials.new("test_key", "test_secret")
+    any_instance_of(Aws::STS::Client) do |klass|
+      stub(klass).assume_role(role_arn: "test_arn", role_session_name: "test_session") {
+        raise Aws::STS::Errors::AccessDenied.new("error", "message")
+      }
+    end
     config = CONFIG_TIME_SLICE.split("\n").reject{|x| x =~ /.+aws_.+/}.join("\n")
     config += %[
       <assume_role_credentials>
@@ -702,9 +700,9 @@ EOC
         role_session_name test_session
       </assume_role_credentials>
     ]
-    d = create_time_sliced_driver(config)
-    d.run {}
-    # should not raise an exception
+    d = create_driver(config)
+    # no exception should be raised during normal operation
+    assert_nothing_raised { d.run {} }
   end
 
 end


### PR DESCRIPTION
It will try and assume the role, and provide fake credentials that immediately expire if the role cannot be assumed.

This will allow it to retry, and if/when the assume_role succeeds, it will resume working as expected.